### PR TITLE
Includes beers in search results

### DIFF
--- a/lib/beer_bot/bar_formatter.rb
+++ b/lib/beer_bot/bar_formatter.rb
@@ -1,0 +1,25 @@
+module BeerBot
+  class BarFormatter
+    def self.format(bars)
+      if bars.size > 0
+        "`Bars`\n#{self.build_tap_lists(bars)}"
+      end
+    end
+
+  private
+    extend Pluralizer
+
+    def self.build_tap_lists(bars)
+      bars.each_with_index.inject([]) do |lines, (bar, index)|
+        beers = bar.beers
+        lines << "#{index + 1}. *#{bar.name}* has " +
+                 "#{string_with_count('beer', beers.size)} " +
+                 "on tap as of #{bar.updated_at}"
+        beers.each do |beer|
+          lines << "    * *#{beer[:name]}* _(#{beer[:style]}, #{beer[:origin]})_"
+        end
+        lines
+      end.join("\n")
+    end
+  end
+end

--- a/lib/beer_bot/bar_formatter.rb
+++ b/lib/beer_bot/bar_formatter.rb
@@ -16,7 +16,7 @@ module BeerBot
                  "#{string_with_count('beer', beers.size)} " +
                  "on tap as of #{bar.updated_at}"
         beers.each do |beer|
-          lines << "    * *#{beer[:name]}* _(#{beer[:style]}, #{beer[:origin]})_"
+          lines << "    * *#{beer[:name]}* _(#{beer[:style]}; #{beer[:origin]})_"
         end
         lines
       end.join("\n")

--- a/lib/beer_bot/beer_formatter.rb
+++ b/lib/beer_bot/beer_formatter.rb
@@ -1,0 +1,31 @@
+module BeerBot
+  class BeerFormatter
+    def self.format(beers)
+      if beers.size > 0
+        "`Beers`\n#{self.build_bars_and_events(beers)}"
+      end
+    end
+
+  private
+    extend Pluralizer
+
+    def self.build_bars_and_events(beers)
+      beers.each_with_index.inject([]) do |lines, (beer, index)|
+        bars = beer.bars
+        events = beer.events
+        lines << "#{index + 1}. *#{beer.name}* _(#{beer.style}, " +
+                 "#{beer.origin})_ is on tap at " +
+                 "#{string_with_count('bar', bars.size)} and " +
+                 "#{string_with_count('event', events.size)}"
+        bars.each do |bar|
+          lines << "    * *#{bar[:name]}* (#{bar[:address]}) as of #{bar[:updated_at]}"
+        end
+        events.each do |event|
+          lines << "    * *#{event[:name]}* on #{event[:date]} " +
+                   "at #{event[:bar]} (#{event[:address]})"
+        end
+        lines
+      end.join("\n")
+    end
+  end
+end

--- a/lib/beer_bot/beer_formatter.rb
+++ b/lib/beer_bot/beer_formatter.rb
@@ -13,7 +13,7 @@ module BeerBot
       beers.each_with_index.inject([]) do |lines, (beer, index)|
         bars = beer.bars
         events = beer.events
-        lines << "#{index + 1}. *#{beer.name}* _(#{beer.style}, " +
+        lines << "#{index + 1}. *#{beer.name}* _(#{beer.style}; " +
                  "#{beer.origin})_ is on tap at " +
                  "#{string_with_count('bar', bars.size)} and " +
                  "#{string_with_count('event', events.size)}"

--- a/lib/beer_bot/formatter.rb
+++ b/lib/beer_bot/formatter.rb
@@ -1,0 +1,39 @@
+module BeerBot
+  class Formatter
+
+    def format(result, request_params)
+      lines = []
+      lines << "@#{request_params['user_name']}: I #{found(result)} #{bar_or_bars(result)} for '#{request_params['text']}'."
+      lines += build_tap_lists(result)
+      lines.join("\n")
+    end
+
+    def found(result)
+      case result.size
+      when 0
+        found = 'didn\'t find any'
+      else
+        found = "found #{result.size}"
+      end
+    end
+
+    def bar_or_bars(result)
+      result.size == 1 ? 'bar' : 'bars'
+    end
+
+    def build_tap_lists(result)
+      result.each_with_index.inject([]) do |lines, (bar, index)|
+        beers = bar.beers
+        lines << "#{index + 1}. *#{bar.name}* has #{beers.size} #{beer_or_beers(beers)} on tap"
+        beers.each do |beer|
+          lines << "    * *#{beer[:name]}* _(#{beer[:style]}, #{beer[:origin]})_"
+        end
+        lines
+      end
+    end
+
+    def beer_or_beers(list)
+      list.size == 1 ? 'beer' : 'beers'
+    end
+  end
+end

--- a/lib/beer_bot/formatter.rb
+++ b/lib/beer_bot/formatter.rb
@@ -3,28 +3,15 @@ module BeerBot
 
     def format(result, request_params)
       lines = []
-      lines << "@#{request_params['user_name']}: I #{found(result)} #{bar_or_bars(result)} for '#{request_params['text']}'."
+      lines << "@#{request_params['user_name']}: PhillyTapFinder returned #{string_with_count('bar', result.size)} for '#{request_params['text']}'."
       lines += build_tap_lists(result)
       lines.join("\n")
-    end
-
-    def found(result)
-      case result.size
-      when 0
-        found = 'didn\'t find any'
-      else
-        found = "found #{result.size}"
-      end
-    end
-
-    def bar_or_bars(result)
-      result.size == 1 ? 'bar' : 'bars'
     end
 
     def build_tap_lists(result)
       result.each_with_index.inject([]) do |lines, (bar, index)|
         beers = bar.beers
-        lines << "#{index + 1}. *#{bar.name}* has #{beers.size} #{beer_or_beers(beers)} on tap"
+        lines << "#{index + 1}. *#{bar.name}* has #{string_with_count('beer', beers.size)} on tap"
         beers.each do |beer|
           lines << "    * *#{beer[:name]}* _(#{beer[:style]}, #{beer[:origin]})_"
         end
@@ -32,8 +19,14 @@ module BeerBot
       end
     end
 
-    def beer_or_beers(list)
-      list.size == 1 ? 'beer' : 'beers'
+  private
+
+    def string_with_count(string, number)
+      "#{number} #{number == 1 ? string : pluralize(string)}"
+    end
+
+    def pluralize(string)
+      "#{string}s"
     end
   end
 end

--- a/lib/beer_bot/formatter.rb
+++ b/lib/beer_bot/formatter.rb
@@ -1,32 +1,21 @@
+require 'beer_bot/pluralizer'
+require 'beer_bot/bar_formatter'
+
 module BeerBot
   class Formatter
 
-    def format(result, request_params)
-      lines = []
-      lines << "@#{request_params['user_name']}: PhillyTapFinder returned #{string_with_count('bar', result.size)} for '#{request_params['text']}'."
-      lines += build_tap_lists(result)
-      lines.join("\n")
-    end
-
-    def build_tap_lists(result)
-      result.each_with_index.inject([]) do |lines, (bar, index)|
-        beers = bar.beers
-        lines << "#{index + 1}. *#{bar.name}* has #{string_with_count('beer', beers.size)} on tap"
-        beers.each do |beer|
-          lines << "    * *#{beer[:name]}* _(#{beer[:style]}, #{beer[:origin]})_"
-        end
-        lines
-      end
+    def self.format(result, request_params)
+      [build_summary(result, request_params),
+       BarFormatter.format(result[:bars])].join("\n")
     end
 
   private
+    extend Pluralizer
 
-    def string_with_count(string, number)
-      "#{number} #{number == 1 ? string : pluralize(string)}"
-    end
-
-    def pluralize(string)
-      "#{string}s"
+    def self.build_summary(result, request_params)
+      "@#{request_params['user_name']}: PhillyTapFinder returned " +
+      "#{string_with_count('bar', result[:bars].size)} for " +
+      "'#{request_params['text']}'."
     end
   end
 end

--- a/lib/beer_bot/formatter.rb
+++ b/lib/beer_bot/formatter.rb
@@ -1,12 +1,14 @@
 require 'beer_bot/pluralizer'
 require 'beer_bot/bar_formatter'
+require 'beer_bot/beer_formatter'
 
 module BeerBot
   class Formatter
 
     def self.format(result, request_params)
       [build_summary(result, request_params),
-       BarFormatter.format(result[:bars])].join("\n")
+       BarFormatter.format(result[:bars]),
+       BeerFormatter.format(result[:beers])].join("\n")
     end
 
   private
@@ -14,7 +16,8 @@ module BeerBot
 
     def self.build_summary(result, request_params)
       "@#{request_params['user_name']}: PhillyTapFinder returned " +
-      "#{string_with_count('bar', result[:bars].size)} for " +
+      "#{string_with_count('bar', result[:bars].size)} and " +
+      "#{string_with_count('beer', result[:beers].size)} for " +
       "'#{request_params['text']}'."
     end
   end

--- a/lib/beer_bot/pluralizer.rb
+++ b/lib/beer_bot/pluralizer.rb
@@ -1,0 +1,11 @@
+module BeerBot
+  module Pluralizer
+    def string_with_count(string, number)
+      "#{number} #{number == 1 ? string : pluralize(string)}"
+    end
+
+    def pluralize(string)
+      "#{string}s"
+    end
+  end
+end

--- a/lib/beer_bot/response.rb
+++ b/lib/beer_bot/response.rb
@@ -13,15 +13,8 @@ module BeerBot
         username: 'BeerBot',
         icon_emoji: ':beers:',
         channel: @request_params['channel_id'],
-        text: format_result
+        text: Formatter.format(@result, @request_params)
       }.to_json
-    end
-
-  private
-
-    def format_result
-      formatter = Formatter.new
-      formatter.format(@result, @request_params)
     end
   end
 end

--- a/lib/beer_bot/response.rb
+++ b/lib/beer_bot/response.rb
@@ -1,7 +1,9 @@
+require 'beer_bot/formatter'
+
 module BeerBot
   class Response
-    def initialize(bars, request_params)
-      @bars = bars
+    def initialize(result, request_params)
+      @result = result
       @request_params = request_params
     end
 
@@ -11,40 +13,15 @@ module BeerBot
         username: 'BeerBot',
         icon_emoji: ':beers:',
         channel: @request_params['channel_id'],
-        text: build_response_text
+        text: format_result
       }.to_json
     end
 
   private
 
-    def build_response_text
-      lines = []
-      lines << "@#{@request_params['user_name']}: I #{found} #{bar_or_bars} for '#{@request_params['text']}'."
-      lines += build_tap_lists
-      lines.join("\n")
-    end
-
-    def found
-      case @bars.size
-      when 0
-        found = 'didn\'t find any'
-      else
-        found = "found #{@bars.size}"
-      end
-    end
-
-    def bar_or_bars
-      @bars.size == 1 ? 'bar' : 'bars'
-    end
-
-    def build_tap_lists
-      @bars.each_with_index.inject([]) do |lines, (bar, index)|
-        lines << "#{index + 1}. *#{bar.name}* has #{bar.beers.size} beers on tap"
-        bar.beers.each do |beer|
-          lines << "    * *#{beer[:name]}* _(#{beer[:style]}, #{beer[:origin]})_"
-        end
-        lines
-      end
+    def format_result
+      formatter = Formatter.new
+      formatter.format(@result, @request_params)
     end
   end
 end

--- a/lib/tapfinder/bar.rb
+++ b/lib/tapfinder/bar.rb
@@ -6,14 +6,14 @@ module Tapfinder
     end
 
     def updated_at
-      @doc.css('#bar-detail .tap-list .bar-data .red').text
+      @doc.css('#bar-detail .tap-list .bar-data .red').text.sub(/Updated:\s+/,'')
     end
 
     def beers
       @doc.css('#bar-detail .tap-list .grid-list .panel').collect do |beer|
         {
-          style: beer.css('.beer-meta h5:first-child').text,
-          origin: beer.css('.beer-meta h5:nth-child(2)').text,
+          style: beer.css('.beer-meta h5:first-child').text.sub(/Style:\s+/,''),
+          origin: beer.css('.beer-meta h5:nth-child(2)').text.sub(/Origin:\s+/,''),
           name: beer.css('h4 a[href^="/beer"]').text
         }
       end

--- a/lib/tapfinder/beer.rb
+++ b/lib/tapfinder/beer.rb
@@ -18,7 +18,7 @@ module Tapfinder
         {
           name: bar.css('h4 a[href^="/bar"]').text,
           address: bar.css('li:nth-child(2) p').text,
-          updated_at: bar.css('.updated').text
+          updated_at: bar.css('.updated').text.sub(/Last Updated:\s+/,'')
         }
       end
     end

--- a/lib/tapfinder/search.rb
+++ b/lib/tapfinder/search.rb
@@ -8,7 +8,8 @@ module Tapfinder
       when 200
         json_response = JSON.parse(response.body)
         bars = Tapfinder::Bar.load(json_response['bars'])
-        { bars: bars }
+        beers = Tapfinder::Beer.load(json_response['beers'])
+        { bars: bars, beers: beers }
       else
         puts "Failed to search #{client} for #{search_terms_for(params)}"
       end

--- a/lib/tapfinder/search.rb
+++ b/lib/tapfinder/search.rb
@@ -8,6 +8,7 @@ module Tapfinder
       when 200
         json_response = JSON.parse(response.body)
         bars = Tapfinder::Bar.load(json_response['bars'])
+        { bars: bars }
       else
         puts "Failed to search #{client} for #{search_terms_for(params)}"
       end

--- a/test/beer_bot/bar_formatter_test.rb
+++ b/test/beer_bot/bar_formatter_test.rb
@@ -15,8 +15,8 @@ class BarFormatterTest < Minitest::Unit::TestCase
     formatted_result = @under_test.format(@result)
     assert_equal formatted_result, ["`Bars`",
       "1. *The Bar* has 2 beers on tap as of 1/27/2015",
-      "    * *The Beer* _(Swill, Colorado)_",
-      "    * *The Lite Beer* _(Dreck, Missouri)_"].join("\n")
+      "    * *The Beer* _(Swill; Colorado)_",
+      "    * *The Lite Beer* _(Dreck; Missouri)_"].join("\n")
   end
 
   def test_when_one_bar_with_one_beer
@@ -27,7 +27,7 @@ class BarFormatterTest < Minitest::Unit::TestCase
     formatted_result = @under_test.format(@result)
     assert_equal formatted_result, ["`Bars`",
       "1. *The Bar* has 1 beer on tap as of 1/27/2015",
-      "    * *The Beer* _(Swill, Colorado)_"].join("\n")
+      "    * *The Beer* _(Swill; Colorado)_"].join("\n")
   end
 
   def test_when_one_bar_with_no_beers
@@ -49,9 +49,9 @@ class BarFormatterTest < Minitest::Unit::TestCase
     formatted_result = @under_test.format(@result)
     assert_equal formatted_result, ["`Bars`",
       "1. *The First Bar* has 1 beer on tap as of 1/27/2015",
-      "    * *The Lite Beer* _(Dreck, Missouri)_",
+      "    * *The Lite Beer* _(Dreck; Missouri)_",
       "2. *The Second Bar* has 1 beer on tap as of 1/26/2015",
-      "    * *The Beer* _(Swill, Colorado)_"].join("\n")
+      "    * *The Beer* _(Swill; Colorado)_"].join("\n")
   end
 
 private

--- a/test/beer_bot/bar_formatter_test.rb
+++ b/test/beer_bot/bar_formatter_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class BarFormatterTest < Minitest::Unit::TestCase
+  def setup
+    @under_test = BeerBot::BarFormatter
+    @result = []
+  end
+
+  def test_when_one_bar_with_multiple_beers
+    mock_bar 'The Bar', [
+      { name: 'The Beer', style: 'Swill', origin: 'Colorado' },
+      { name: 'The Lite Beer', style: 'Dreck', origin: 'Missouri' }
+    ], '1/27/2015'
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Bars`",
+      "1. *The Bar* has 2 beers on tap as of 1/27/2015",
+      "    * *The Beer* _(Swill, Colorado)_",
+      "    * *The Lite Beer* _(Dreck, Missouri)_"].join("\n")
+  end
+
+  def test_when_one_bar_with_one_beer
+    mock_bar 'The Bar', [
+      { name: 'The Beer', style: 'Swill', origin: 'Colorado' }
+    ], '1/27/2015'
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Bars`",
+      "1. *The Bar* has 1 beer on tap as of 1/27/2015",
+      "    * *The Beer* _(Swill, Colorado)_"].join("\n")
+  end
+
+  def test_when_one_bar_with_no_beers
+    mock_bar 'The Bar', [], '1/27/2015'
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Bars`",
+      "1. *The Bar* has 0 beers on tap as of 1/27/2015"].join("\n")
+  end
+
+  def test_when_multiple_bars_with_one_beer
+    mock_bar 'The First Bar', [
+      { name: 'The Lite Beer', style: 'Dreck', origin: 'Missouri' }
+    ], '1/27/2015'
+    mock_bar 'The Second Bar', [
+      { name: 'The Beer', style: 'Swill', origin: 'Colorado' }
+    ], '1/26/2015'
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Bars`",
+      "1. *The First Bar* has 1 beer on tap as of 1/27/2015",
+      "    * *The Lite Beer* _(Dreck, Missouri)_",
+      "2. *The Second Bar* has 1 beer on tap as of 1/26/2015",
+      "    * *The Beer* _(Swill, Colorado)_"].join("\n")
+  end
+
+private
+
+  # TODO: Refactor the bar
+  # class so that it can
+  # be stubbed here instead
+  def mock_bar(name, beers, updated_at)
+    bar = Minitest::Mock.new
+    bar.expect :name, name
+    bar.expect :beers, beers
+    bar.expect :updated_at, updated_at
+    @result << bar
+  end
+end

--- a/test/beer_bot/beer_formatter_test.rb
+++ b/test/beer_bot/beer_formatter_test.rb
@@ -1,0 +1,100 @@
+require 'test_helper'
+
+class BeerFormatterTest < Minitest::Unit::TestCase
+  def setup
+    @under_test = BeerBot::BeerFormatter
+    @result = []
+  end
+
+  def test_when_one_beer_at_multiple_bars_and_no_events
+    mock_beer 'The Beer', 'Style', 'Origin', [
+      { name: 'Good Bar', address: 'Awesometown', updated_at: '1/27/2015' },
+      { name: 'Shitty Bar', address: 'Wherever', updated_at: '1/26/2015' }
+    ], []
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Beers`",
+      "1. *The Beer* _(Style, Origin)_ is on tap at 2 bars and 0 events",
+      "    * *Good Bar* (Awesometown) as of 1/27/2015",
+      "    * *Shitty Bar* (Wherever) as of 1/26/2015"].join("\n")
+  end
+
+  def test_when_one_beer_at_one_bar_and_no_events
+    mock_beer 'The Beer', 'Style', 'Origin', [
+      { name: 'Shitty Bar', address: 'Wherever', updated_at: '1/26/2015' }
+    ], []
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Beers`",
+      "1. *The Beer* _(Style, Origin)_ is on tap at 1 bar and 0 events",
+      "    * *Shitty Bar* (Wherever) as of 1/26/2015"].join("\n")
+  end
+
+  def test_when_one_beer_at_one_bar_and_one_event
+    mock_beer 'The Beer', 'Style', 'Origin', [
+      { name: 'Good Bar', address: 'Awesometown', updated_at: '1/27/2015' }
+    ], [
+      { name: 'Shitty Event', bar: 'Shitty Bar', address: 'Wherever', date: '1/31/2015' }
+    ]
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Beers`",
+      "1. *The Beer* _(Style, Origin)_ is on tap at 1 bar and 1 event",
+      "    * *Good Bar* (Awesometown) as of 1/27/2015",
+      "    * *Shitty Event* on 1/31/2015 at Shitty Bar (Wherever)"].join("\n")
+  end
+
+  def test_when_one_beer_at_no_bars_and_multiple_events
+    mock_beer 'The Beer', 'Style', 'Origin', [], [
+      { name: 'Good Event', bar: 'Good Bar', address: 'Awesometown', date: '2/1/2015' },
+      { name: 'Shitty Event', bar: 'Shitty Bar', address: 'Wherever', date: '2/12/2015' }
+    ]
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Beers`",
+      "1. *The Beer* _(Style, Origin)_ is on tap at 0 bars and 2 events",
+      "    * *Good Event* on 2/1/2015 at Good Bar (Awesometown)",
+      "    * *Shitty Event* on 2/12/2015 at Shitty Bar (Wherever)"].join("\n")
+  end
+
+  def test_when_one_beer_at_no_bars_or_events
+    mock_beer 'The Beer', 'Style', 'Origin', [], []
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Beers`",
+      "1. *The Beer* _(Style, Origin)_ is on tap at 0 bars and 0 events"].join("\n")
+  end
+
+  def test_when_multiple_beers_at_one_bar_and_no_events
+    mock_beer 'The Beer', 'Style', 'Origin', [
+      { name: 'Shitty Bar', address: 'Wherever', updated_at: '1/26/2015' }
+    ], []
+
+    mock_beer 'The Lite Beer', 'Style 2', 'Origin 2', [
+      { name: 'Good Bar', address: 'Awesometown', updated_at: '1/27/2015' }
+    ], []
+
+    formatted_result = @under_test.format(@result)
+    assert_equal formatted_result, ["`Beers`",
+      "1. *The Beer* _(Style, Origin)_ is on tap at 1 bar and 0 events",
+      "    * *Shitty Bar* (Wherever) as of 1/26/2015",
+      "2. *The Lite Beer* _(Style 2, Origin 2)_ is on tap at 1 bar and 0 events",
+      "    * *Good Bar* (Awesometown) as of 1/27/2015"].join("\n")
+  end
+
+
+private
+
+  # TODO: Refactor the bar
+  # class so that it can
+  # be stubbed here instead
+  def mock_beer(name, style, origin, bars, events)
+    beer = Minitest::Mock.new
+    beer.expect :name, name
+    beer.expect :style, style
+    beer.expect :origin, origin
+    beer.expect :bars, bars
+    beer.expect :events, events
+    @result << beer
+  end
+end

--- a/test/beer_bot/beer_formatter_test.rb
+++ b/test/beer_bot/beer_formatter_test.rb
@@ -14,7 +14,7 @@ class BeerFormatterTest < Minitest::Unit::TestCase
 
     formatted_result = @under_test.format(@result)
     assert_equal formatted_result, ["`Beers`",
-      "1. *The Beer* _(Style, Origin)_ is on tap at 2 bars and 0 events",
+      "1. *The Beer* _(Style; Origin)_ is on tap at 2 bars and 0 events",
       "    * *Good Bar* (Awesometown) as of 1/27/2015",
       "    * *Shitty Bar* (Wherever) as of 1/26/2015"].join("\n")
   end
@@ -26,7 +26,7 @@ class BeerFormatterTest < Minitest::Unit::TestCase
 
     formatted_result = @under_test.format(@result)
     assert_equal formatted_result, ["`Beers`",
-      "1. *The Beer* _(Style, Origin)_ is on tap at 1 bar and 0 events",
+      "1. *The Beer* _(Style; Origin)_ is on tap at 1 bar and 0 events",
       "    * *Shitty Bar* (Wherever) as of 1/26/2015"].join("\n")
   end
 
@@ -39,7 +39,7 @@ class BeerFormatterTest < Minitest::Unit::TestCase
 
     formatted_result = @under_test.format(@result)
     assert_equal formatted_result, ["`Beers`",
-      "1. *The Beer* _(Style, Origin)_ is on tap at 1 bar and 1 event",
+      "1. *The Beer* _(Style; Origin)_ is on tap at 1 bar and 1 event",
       "    * *Good Bar* (Awesometown) as of 1/27/2015",
       "    * *Shitty Event* on 1/31/2015 at Shitty Bar (Wherever)"].join("\n")
   end
@@ -52,7 +52,7 @@ class BeerFormatterTest < Minitest::Unit::TestCase
 
     formatted_result = @under_test.format(@result)
     assert_equal formatted_result, ["`Beers`",
-      "1. *The Beer* _(Style, Origin)_ is on tap at 0 bars and 2 events",
+      "1. *The Beer* _(Style; Origin)_ is on tap at 0 bars and 2 events",
       "    * *Good Event* on 2/1/2015 at Good Bar (Awesometown)",
       "    * *Shitty Event* on 2/12/2015 at Shitty Bar (Wherever)"].join("\n")
   end
@@ -62,7 +62,7 @@ class BeerFormatterTest < Minitest::Unit::TestCase
 
     formatted_result = @under_test.format(@result)
     assert_equal formatted_result, ["`Beers`",
-      "1. *The Beer* _(Style, Origin)_ is on tap at 0 bars and 0 events"].join("\n")
+      "1. *The Beer* _(Style; Origin)_ is on tap at 0 bars and 0 events"].join("\n")
   end
 
   def test_when_multiple_beers_at_one_bar_and_no_events
@@ -76,9 +76,9 @@ class BeerFormatterTest < Minitest::Unit::TestCase
 
     formatted_result = @under_test.format(@result)
     assert_equal formatted_result, ["`Beers`",
-      "1. *The Beer* _(Style, Origin)_ is on tap at 1 bar and 0 events",
+      "1. *The Beer* _(Style; Origin)_ is on tap at 1 bar and 0 events",
       "    * *Shitty Bar* (Wherever) as of 1/26/2015",
-      "2. *The Lite Beer* _(Style 2, Origin 2)_ is on tap at 1 bar and 0 events",
+      "2. *The Lite Beer* _(Style 2; Origin 2)_ is on tap at 1 bar and 0 events",
       "    * *Good Bar* (Awesometown) as of 1/27/2015"].join("\n")
   end
 

--- a/test/beer_bot/formatter_test.rb
+++ b/test/beer_bot/formatter_test.rb
@@ -6,30 +6,50 @@ class FormatterTest < Minitest::Unit::TestCase
     @request_params = { 'user_name' => 'User', 'text' => 'search text' }
   end
 
-  def test_when_no_bars
-    with_stubbed_bar_formatter do
-      search_result = { bars: [] }
-      formatted_result = @under_test.format(search_result, @request_params)
-      assert_equal formatted_result, ["@User: PhillyTapFinder returned 0 bars for 'search text'.",
-        "Bar formatter output"].join("\n")
+  def test_when_no_bars_or_beers
+    with_stubbed_beer_formatter do
+      with_stubbed_bar_formatter do
+        search_result = { bars: [], beers: [] }
+        formatted_result = @under_test.format(search_result, @request_params)
+        assert_equal formatted_result, ["@User: PhillyTapFinder returned 0 bars and 0 beers for 'search text'.",
+          "Bar formatter output", "Beer formatter output"].join("\n")
+      end
     end
   end
 
-  def test_when_one_bar
-    with_stubbed_bar_formatter do
-      search_result = { bars: [ 'The only bar' ] }
-      formatted_result = @under_test.format(search_result, @request_params)
-      assert_equal formatted_result, ["@User: PhillyTapFinder returned 1 bar for 'search text'.",
-        "Bar formatter output"].join("\n")
+  def test_when_one_bar_and_no_beers
+    with_stubbed_beer_formatter do
+      with_stubbed_bar_formatter do
+        search_result = { bars: [ 'The only bar' ], beers: [] }
+        formatted_result = @under_test.format(search_result, @request_params)
+        assert_equal formatted_result, ["@User: PhillyTapFinder returned 1 bar and 0 beers for 'search text'.",
+          "Bar formatter output", "Beer formatter output"].join("\n")
+      end
     end
   end
 
-  def test_when_multiple_bars
-    with_stubbed_bar_formatter do
-      search_result = { bars: [ 'The only bar', 'The other bar' ] }
-      formatted_result = @under_test.format(search_result, @request_params)
-      assert_equal formatted_result, ["@User: PhillyTapFinder returned 2 bars for 'search text'.",
-        "Bar formatter output"].join("\n")
+  def test_when_no_bars_and_one_beer
+    with_stubbed_beer_formatter do
+      with_stubbed_bar_formatter do
+        search_result = { bars: [], beers: ['one'] }
+        formatted_result = @under_test.format(search_result, @request_params)
+        assert_equal formatted_result, ["@User: PhillyTapFinder returned 0 bars and 1 beer for 'search text'.",
+          "Bar formatter output", "Beer formatter output"].join("\n")
+      end
+    end
+  end
+
+  def test_when_multiple_bars_and_beers
+    with_stubbed_beer_formatter do
+      with_stubbed_bar_formatter do
+        search_result = {
+          bars: [ 'The only bar', 'The other bar' ],
+          beers: [ 'one', 'two', 'three']
+        }
+        formatted_result = @under_test.format(search_result, @request_params)
+        assert_equal formatted_result, ["@User: PhillyTapFinder returned 2 bars and 3 beers for 'search text'.",
+          "Bar formatter output", "Beer formatter output"].join("\n")
+      end
     end
   end
 
@@ -37,6 +57,12 @@ private
 
   def with_stubbed_bar_formatter
     BeerBot::BarFormatter.stub :format, "Bar formatter output" do
+      yield
+    end
+  end
+
+  def with_stubbed_beer_formatter
+    BeerBot::BeerFormatter.stub :format, "Beer formatter output" do
       yield
     end
   end

--- a/test/beer_bot/formatter_test.rb
+++ b/test/beer_bot/formatter_test.rb
@@ -2,72 +2,42 @@ require 'test_helper'
 
 class FormatterTest < Minitest::Unit::TestCase
   def setup
-    @under_test = BeerBot::Formatter.new
+    @under_test = BeerBot::Formatter
     @request_params = { 'user_name' => 'User', 'text' => 'search text' }
-    @result = []
-  end
-
-  def test_when_one_bar_with_multiple_beers
-    mock_bar 'The Bar', [
-      { name: 'The Beer', style: 'Swill', origin: 'Colorado' },
-      { name: 'The Lite Beer', style: 'Dreck', origin: 'Missouri' }
-    ]
-
-    formatted_result = @under_test.format(@result, @request_params)
-    assert_equal formatted_result, ["@User: PhillyTapFinder returned 1 bar for 'search text'.",
-      "1. *The Bar* has 2 beers on tap",
-      "    * *The Beer* _(Swill, Colorado)_",
-      "    * *The Lite Beer* _(Dreck, Missouri)_"].join("\n")
-  end
-
-  def test_when_one_bar_with_one_beer
-    mock_bar 'The Bar', [
-      { name: 'The Beer', style: 'Swill', origin: 'Colorado' }
-    ]
-
-    formatted_result = @under_test.format(@result, @request_params)
-    assert_equal formatted_result, ["@User: PhillyTapFinder returned 1 bar for 'search text'.",
-      "1. *The Bar* has 1 beer on tap",
-      "    * *The Beer* _(Swill, Colorado)_"].join("\n")
-  end
-
-  def test_when_one_bar_with_no_beers
-    mock_bar 'The Bar', []
-
-    formatted_result = @under_test.format(@result, @request_params)
-    assert_equal formatted_result, ["@User: PhillyTapFinder returned 1 bar for 'search text'.",
-      "1. *The Bar* has 0 beers on tap"].join("\n")
-  end
-
-  def test_when_multiple_bars
-    mock_bar 'The First Bar', []
-    mock_bar 'The Second Bar', []
-
-    formatted_result = @under_test.format(@result, @request_params)
-    assert_equal formatted_result, ["@User: PhillyTapFinder returned 2 bars for 'search text'.",
-      "1. *The First Bar* has 0 beers on tap",
-      "2. *The Second Bar* has 0 beers on tap"].join("\n")
   end
 
   def test_when_no_bars
-    mock_bar 'The First Bar', []
-    mock_bar 'The Second Bar', []
+    with_stubbed_bar_formatter do
+      search_result = { bars: [] }
+      formatted_result = @under_test.format(search_result, @request_params)
+      assert_equal formatted_result, ["@User: PhillyTapFinder returned 0 bars for 'search text'.",
+        "Bar formatter output"].join("\n")
+    end
+  end
 
-    formatted_result = @under_test.format(@result, @request_params)
-    assert_equal formatted_result, ["@User: PhillyTapFinder returned 2 bars for 'search text'.",
-      "1. *The First Bar* has 0 beers on tap",
-      "2. *The Second Bar* has 0 beers on tap"].join("\n")
+  def test_when_one_bar
+    with_stubbed_bar_formatter do
+      search_result = { bars: [ 'The only bar' ] }
+      formatted_result = @under_test.format(search_result, @request_params)
+      assert_equal formatted_result, ["@User: PhillyTapFinder returned 1 bar for 'search text'.",
+        "Bar formatter output"].join("\n")
+    end
+  end
+
+  def test_when_multiple_bars
+    with_stubbed_bar_formatter do
+      search_result = { bars: [ 'The only bar', 'The other bar' ] }
+      formatted_result = @under_test.format(search_result, @request_params)
+      assert_equal formatted_result, ["@User: PhillyTapFinder returned 2 bars for 'search text'.",
+        "Bar formatter output"].join("\n")
+    end
   end
 
 private
 
-  # TODO: Refactor the bar
-  # class so that it can
-  # be stubbed here instead
-  def mock_bar(name, beers)
-    bar = Minitest::Mock.new
-    bar.expect :name, name
-    bar.expect :beers, beers
-    @result << bar
+  def with_stubbed_bar_formatter
+    BeerBot::BarFormatter.stub :format, "Bar formatter output" do
+      yield
+    end
   end
 end

--- a/test/beer_bot/formatter_test.rb
+++ b/test/beer_bot/formatter_test.rb
@@ -14,7 +14,7 @@ class FormatterTest < Minitest::Unit::TestCase
     ]
 
     formatted_result = @under_test.format(@result, @request_params)
-    assert_equal formatted_result, ["@User: I found 1 bar for 'search text'.",
+    assert_equal formatted_result, ["@User: PhillyTapFinder returned 1 bar for 'search text'.",
       "1. *The Bar* has 2 beers on tap",
       "    * *The Beer* _(Swill, Colorado)_",
       "    * *The Lite Beer* _(Dreck, Missouri)_"].join("\n")
@@ -26,7 +26,7 @@ class FormatterTest < Minitest::Unit::TestCase
     ]
 
     formatted_result = @under_test.format(@result, @request_params)
-    assert_equal formatted_result, ["@User: I found 1 bar for 'search text'.",
+    assert_equal formatted_result, ["@User: PhillyTapFinder returned 1 bar for 'search text'.",
       "1. *The Bar* has 1 beer on tap",
       "    * *The Beer* _(Swill, Colorado)_"].join("\n")
   end
@@ -35,7 +35,7 @@ class FormatterTest < Minitest::Unit::TestCase
     mock_bar 'The Bar', []
 
     formatted_result = @under_test.format(@result, @request_params)
-    assert_equal formatted_result, ["@User: I found 1 bar for 'search text'.",
+    assert_equal formatted_result, ["@User: PhillyTapFinder returned 1 bar for 'search text'.",
       "1. *The Bar* has 0 beers on tap"].join("\n")
   end
 
@@ -44,7 +44,17 @@ class FormatterTest < Minitest::Unit::TestCase
     mock_bar 'The Second Bar', []
 
     formatted_result = @under_test.format(@result, @request_params)
-    assert_equal formatted_result, ["@User: I found 2 bars for 'search text'.",
+    assert_equal formatted_result, ["@User: PhillyTapFinder returned 2 bars for 'search text'.",
+      "1. *The First Bar* has 0 beers on tap",
+      "2. *The Second Bar* has 0 beers on tap"].join("\n")
+  end
+
+  def test_when_no_bars
+    mock_bar 'The First Bar', []
+    mock_bar 'The Second Bar', []
+
+    formatted_result = @under_test.format(@result, @request_params)
+    assert_equal formatted_result, ["@User: PhillyTapFinder returned 2 bars for 'search text'.",
       "1. *The First Bar* has 0 beers on tap",
       "2. *The Second Bar* has 0 beers on tap"].join("\n")
   end

--- a/test/beer_bot/formatter_test.rb
+++ b/test/beer_bot/formatter_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class FormatterTest < Minitest::Unit::TestCase
+  def setup
+    @under_test = BeerBot::Formatter.new
+    @request_params = { 'user_name' => 'User', 'text' => 'search text' }
+    @result = []
+  end
+
+  def test_when_one_bar_with_multiple_beers
+    mock_bar 'The Bar', [
+      { name: 'The Beer', style: 'Swill', origin: 'Colorado' },
+      { name: 'The Lite Beer', style: 'Dreck', origin: 'Missouri' }
+    ]
+
+    formatted_result = @under_test.format(@result, @request_params)
+    assert_equal formatted_result, ["@User: I found 1 bar for 'search text'.",
+      "1. *The Bar* has 2 beers on tap",
+      "    * *The Beer* _(Swill, Colorado)_",
+      "    * *The Lite Beer* _(Dreck, Missouri)_"].join("\n")
+  end
+
+  def test_when_one_bar_with_one_beer
+    mock_bar 'The Bar', [
+      { name: 'The Beer', style: 'Swill', origin: 'Colorado' }
+    ]
+
+    formatted_result = @under_test.format(@result, @request_params)
+    assert_equal formatted_result, ["@User: I found 1 bar for 'search text'.",
+      "1. *The Bar* has 1 beer on tap",
+      "    * *The Beer* _(Swill, Colorado)_"].join("\n")
+  end
+
+  def test_when_one_bar_with_no_beers
+    mock_bar 'The Bar', []
+
+    formatted_result = @under_test.format(@result, @request_params)
+    assert_equal formatted_result, ["@User: I found 1 bar for 'search text'.",
+      "1. *The Bar* has 0 beers on tap"].join("\n")
+  end
+
+  def test_when_multiple_bars
+    mock_bar 'The First Bar', []
+    mock_bar 'The Second Bar', []
+
+    formatted_result = @under_test.format(@result, @request_params)
+    assert_equal formatted_result, ["@User: I found 2 bars for 'search text'.",
+      "1. *The First Bar* has 0 beers on tap",
+      "2. *The Second Bar* has 0 beers on tap"].join("\n")
+  end
+
+private
+
+  # TODO: Refactor the bar
+  # class so that it can
+  # be stubbed here instead
+  def mock_bar(name, beers)
+    bar = Minitest::Mock.new
+    bar.expect :name, name
+    bar.expect :beers, beers
+    @result << bar
+  end
+end

--- a/test/tapfinder/bar_test.rb
+++ b/test/tapfinder/bar_test.rb
@@ -12,16 +12,16 @@ describe Tapfinder::Bar do
   end
 
   it 'should have the correct updated date' do
-    @bar.updated_at.must_equal 'Updated: 01/16/2015'
+    @bar.updated_at.must_equal '01/16/2015'
   end
 
   it 'should have the correct tap list' do
     @bar.beers.must_equal [
-      { style: 'Style: Barleywine', origin: 'Origin: Comstock, MI', name: 'Bell\'s Third Coast'},
-      { style: 'Style: Saison/Farmhouse Ale', origin: 'Origin: Kansas City, MO', name: 'Boulevard Tank 7' },
-      { style: 'Style: IPA', origin: 'Origin: Allentown, PA', name: 'Fegley\'s Brew Works Hop\'Solutely' },
-      { style: 'Style: IPA', origin: 'Origin: Boston, MA', name: 'Harpoon IPA' },
-      { style: 'Style: Pale Ale', origin: 'Origin: Lyons, CO', name: 'Oskar Blues Dale\'s Pale Ale' }
+      { style: 'Barleywine', origin: 'Comstock, MI', name: 'Bell\'s Third Coast'},
+      { style: 'Saison/Farmhouse Ale', origin: 'Kansas City, MO', name: 'Boulevard Tank 7' },
+      { style: 'IPA', origin: 'Allentown, PA', name: 'Fegley\'s Brew Works Hop\'Solutely' },
+      { style: 'IPA', origin: 'Boston, MA', name: 'Harpoon IPA' },
+      { style: 'Pale Ale', origin: 'Lyons, CO', name: 'Oskar Blues Dale\'s Pale Ale' }
     ]
   end
 end

--- a/test/tapfinder/beer_test.rb
+++ b/test/tapfinder/beer_test.rb
@@ -21,7 +21,7 @@ describe Tapfinder::Beer do
 
   it 'should have the correct bar list' do
     @beer.bars.must_equal [
-      { name: 'Pinocchio\'s', address: '131 E. Baltimore Ave., Media, PA', updated_at: 'Last Updated: 01/20/15' }
+      { name: 'Pinocchio\'s', address: '131 E. Baltimore Ave., Media, PA', updated_at: '01/20/15' }
     ]
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require 'simplecov'
 SimpleCov.start do
   add_filter 'vendor'
 end
-SimpleCov.minimum_coverage 87.43
+SimpleCov.minimum_coverage 90.61
 
 require 'minitest/autorun'
 require 'vcr'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require 'simplecov'
 SimpleCov.start do
   add_filter 'vendor'
 end
-SimpleCov.minimum_coverage 83.56
+SimpleCov.minimum_coverage 87.43
 
 require 'minitest/autorun'
 require 'vcr'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require 'simplecov'
 SimpleCov.start do
   add_filter 'vendor'
 end
-SimpleCov.minimum_coverage 73.02
+SimpleCov.minimum_coverage 83.56
 
 require 'minitest/autorun'
 require 'vcr'


### PR DESCRIPTION
This closes #3. BeerBot responses now include both bars and beers.  In addition, a couple formatting issues were cleaned up:

1. Switched from comma to semicolon for separating beer style & origin, because origin may already include a comma
2. Removed field labels from style, origin and updated_at fields (for example, beers from tap lists were previously marked as "Style: <style>", now just "<style>")