### PR TITLE
Fixes #5: Don't display events twice when a beer is at 0 bars

### DIFF
--- a/fixtures/vcr_cassettes/cantillon.yml
+++ b/fixtures/vcr_cassettes/cantillon.yml
@@ -1,0 +1,228 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.phillytapfinder.com/?p=35601
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Fri, 23 Jan 2015 15:27:04 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - PHP/5.4.6-1ubuntu1.8
+      Vary:
+      - Accept-Encoding,Cookie
+      X-Pingback:
+      - http://www.phillytapfinder.com/wordpress/xmlrpc.php
+      Expires:
+      - Wed, 11 Jan 1984 05:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate, max-age=0
+      Pragma:
+      - no-cache
+      Location:
+      - http://www.phillytapfinder.com/beer/russian-river-consecration/
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Content-Length:
+      - '25'
+      Age:
+      - '0'
+      Via:
+      - 1.1 localhost.localdomain
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    http_version: 
+  recorded_at: Fri, 23 Jan 2015 15:27:04 GMT
+- request:
+    method: get
+    uri: http://www.phillytapfinder.com/beer/russian-river-consecration/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 23 Jan 2015 15:27:04 GMT
+      Server:
+      - Apache/2.2.22 (Ubuntu)
+      X-Powered-By:
+      - PHP/5.4.6-1ubuntu1.8
+      Vary:
+      - Accept-Encoding,Cookie
+      X-Pingback:
+      - http://www.phillytapfinder.com/wordpress/xmlrpc.php
+      Link:
+      - "<http://www.phillytapfinder.com/?p=35601>; rel=shortlink"
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Content-Length:
+      - '5759'
+      Age:
+      - '1'
+      Via:
+      - 1.1 localhost.localdomain
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+08a3PbOJKfnV+BcPcseyO+JFmWH1TKySSzucrr4mRmq3Ip
+        F0SCEh2K4BCkZU3W/+y+3R+7bgCkSImO5Wyyt3u3qlRMAo1Go7vRDzx4+jDg
+        fr5MGZnl83j84PShaX6MQhLn5MUzcvhpTE6xgvgxFcIzEm5eChKxIeFxEDGD
+        xDSZegZLzA/nBsA+/MiSIAo/meYKlcYDv1ZUh/dDNfoKqtH9UB19BdXRPVBN
+        c40NC9oYtonFNJuYZowG4wc7p3OWU+LPaCZY7hkf3j83RwaxsSaOks8kY7Fn
+        BIkw04yFLPdnBpnBk2fYNr2k19aU82nMaBoJy+dzbIldkTPy0+tzYsxoEogZ
+        /QyjyjkRKWMByWdRMhWkSAnSsSPBPwgG5YxYs5z6PhOCQEPoe86vZAVUAzVM
+        IBZ6xaOAsGDKiE+hIhKiYMIir3gGL0nIj8nsYJIiOfbE7h+OdD9yoLM8T032
+        WxFdecZfzA9n5lM+T2keTWIg0edJzhLgwotnHuLv+rOMz5nnGtg+j/KYwcMO
+        Ie8KISKakHfRFcvIU54I5meAhSeEmOTtLIrj5XuaPo+SgGVIyM6pXTavsTXN
+        eBhhx4qjSNuxbU/n6dTi2dS+DhPbdTeEIfJlzMSMsXyt4WKxsFLZd07TsOrb
+        XqSmHpkNrJwzYa9B2RKl5Qvx+Mpzhs6g57iDjX5TENuE+p+37ZVnAeiMEPb1
+        PM5SH4BShbPEKtF0NJoQKBRr2mQjRSGdR/HSe0djtqDLjqSls+JBh6Ap8To5
+        u84RvjP+JvRncxCf/+j86fHAcbqHjrNNR6ALSqtAkCnL8qVn8OmxFHRNmb5B
+        Xapp9PwJeZOyhPyc0XRGJtHvXVIIkAMRoJdEsESg5pKAhbSIc1HX9CZNQHqN
+        pCADBmkBbwIXWVyDvUPMEwb6k6kBmhkOEJWtGqB9ay/RnE7ZZj/fpsDRfGpH
+        2UXMp9xKk+mtnYooZxcJndc7voX/7cINmPCzKMWh1VCcgQwWUT4jfpFlFDSN
+        0CAAU4dGDEYZgFkinH4mE5qBVgmrnb5wckyDeZSIGma35w4d5/Bw4JY0rSYk
+        jXOWJTRH44qqadA0jSNf8T0T4hFMPKhCdfSMd+fn5Dma35C3a9xWkzoEDHap
+        nYgSqVFKp/hCROZ/B4N0Kew4mgh7zuEtiX7PzJ7lWEMLuGOBcxuf2qq7hoXq
+        gLm56ugBd97xacHIOcyTjLwBoYC7+DNP2JKAsDpN4/B13UY8Js63zOQSjzlD
+        PCYYJLuDQqlRkIBxWFHQmPZvAWopndyzGDq4FwmN6ZUiIhMQmQwRbdAgZjzL
+        8XXLLh6nXv9g6LgdpZTS4mmFKm2dMbYy5oO8AH7OpH5/CSKRxnR5HCXomcnD
+        aJ5Cv6D8JykoP9ioY6deOKfZNEqaZTenyvOAJVVBQxzjTHkD6M6fvSFvwdmQ
+        nuVaQzJZklcRBCksJu95NoH5QnhIztkcpg55HpFf2YT8xEQ0TT6abtd0P0lL
+        qCYYTncwed9v4taYbfg04QnMuXjLCbSduaxmU00Ml/SKqlJDBSFXNCMXU/ob
+        8dSfv/6VfPx0Iqvw3UoLMdv72LmAuO7M93mR5J0u6UDI4w6H7uho2DPdzqf9
+        lgZ5Box/C8O/itiiAtkLi8RHGvf2yRdZokiYUiAAIvoCFcPyMwYG6VnM8G2v
+        owju7J8AmCVjfo901obTkZVULBMfavOsYNjhDpSBLYGSPanA4rhDvFpHMVeG
+        zgL7mXOfx+Qx0YC2LUTcIcekpvmdffKIdHQAYNKEgmAiX4UB0NOl6JzUxiTq
+        Q5qyXI9HPAGjOX0N+rQa2Ufn0wkRVkozAHgN5soCAw76+YSFEI/uTWmXCM3B
+        m/09+VQzXlsIumQ76JsPIdWbIp+ALIOXoIJ7qIddiIJzNuXZskuohFTygR9I
+        NbcugP73KFGWPVlK2vctJeJnVyijjdYnqjFkGXvSvFs5TF2WI/c7FxNIK8Cw
+        7AM1eZElK3GBlr2P5owXIPUNIQE7jQ4IQKLDeYLCMEAdXcdR/Wl0IY2FxHeD
+        hfafINph0NW0iEEq/14xBpxYhnmEIH+yEbDiEdB5lufZHosZjAeeSl6gVCEY
+        hSAJNQqqLQ0aTYqckd1dsl62J5vv47RKijhWXInCPfJQ46nYjLgRGLUGsdAS
+        hThZAcQsmYKd8RSkpV51PYxmD2EiqHZO4M+pBofnR4/2S3lIij5Gn6wE1Awl
+        CSLx9CirsdVhfqGxlo7iZ8llBSwrbhrsoxEX6QWYwJecBko9sE6PVM0NSFJ5
+        EkM9dLYAw8YXlno/UTCoN6jNYJ8b1eQh6E/ZU6dCSdagPIIwGtcN8BMU4Kug
+        NZMkYRQFFZWNGrKiXk1FXX6zekSUtTpdc1Pxqp1fildMmYkuYVf4vwTb/7Ji
+        i65HBaH+TLbZ1x1pybRA7HWAXY/qGDVxyJpbWmuCXkYC3ByD6bBq3VVzbF9L
+        H/+/RepyhHv1CYTTdwvTSDvahuAslYp97YFaX6NaI4ZS+ck1KHc5iWpqI4E+
+        Xn+SFgdMHQP/yQJQGXTbUVKq9M4a96t24OV44kMk/LnTJZsjUWOZLwM+pxGa
+        poQtyDs2fXad7lUjU5WAKSoHs7MjDZdX2Ri0PwCApSsYHIaEA4uCf62cv+QL
+        lj2lAg0vBgLXb0Ll0mBEOIEdhH1Y0mOB2cgliv0VwTsttl93X5YRLBQwYNm0
+        JEdN+52b/ZoVuFlzQjL0sqmKvSCyhbSSkxRjLxlD2Wqh6HTCg2W5xIQpKERO
+        6o+Z5uEFxjWCpFzkUWDKcNIgAc2pGQWeod51T0/OtfVmmN3G0WdGwFbmICHZ
+        XRBdEWwTTsyM8xxDfSiCCk3uKgwJwLN2ARbZpEzTJbyHl1JD21VTSHf9QM3G
+        OsyT5YtgD1CVfg1hNKJmRAO+HCqsCK1PFCgwHacYtg0KmjA/t0Lqswnnn62E
+        5TZLLj6cI38hyvjDdTiZx567C6nai8AbOANn2Heco+HgaHB0aCA+GMCt0YQe
+        IAjwplJV0AEdi8BT2bF5KUTwubO/f7KSM8T2JXNxIoGusUxGGHIpEOJorEEV
+        NNW7rFNttNhTiAnNZlts7aqHnVO6VQxcpaStaajuKgL0LfWnNtW92mW3dQJp
+        YMaS9gmnWWCUdOmgAcfXhDDzeRob9eDr2rz8rWDZUtVoBKuR/fELDS6KLL6p
+        BiFL5DOWyUjJM1SYBLobzacqI5Zg8AZAiyjIZ7pEPkPZjEXTWa4L1QuUQoKv
+        i+CpvUvIxEuWNOJKfJPzpv6k5jLL5HONbZNpU6ow2ZgymsgywWjmz8wJv5bL
+        oF/XB9CGsnYWQSqVGONz2R4sLAYdohTcKSj0vAT1QSZZGF3DkAsM5oH3LIeR
+        8jA0JA1pFkECuTQVLZuaGSVpkUNeHgcrvYzpBNJF6KYcQhqCOUFdIkteZARz
+        dQJ5V5gTtF6ntmygG0uENcUwdBqpMeWartWrrRuKFDJ+TRXMzmXKjfEu96PM
+        x6kIlU2RyOXvemeimMyjvJoH6tWUabIBRg4COs/QHH0qaX8iLe+bhMBEMWy5
+        FtPkjZYfctYMYUYJY3Pi1GFiiBpENXeKuK4EMJFl/WpmxFE1+crGploBHSua
+        gK9RpaBF3I5Xjm97zOdyVXYrzJC5b4/3Cc22wzrjPNge7Z8B+g68CTdVVC62
+        wvjrjGWsIyCKIWGUfQbHjSr8mJzzDDO5hBNFqA71BUwDiBGsVhpWuthQCQyS
+        cTKtbNjfvKqHq7S4aWQq3NY0CuVaYpulQvOA5kZ7f1tbJFx9qZnzmlrebcpP
+        1eBrxhwjxhtj/McvOLlvlCVVPKq5zZb+lLrev0e13GVv13FLv6jMP2qcLd1J
+        Lf+GUWK77QaJe0F1X4OCDBj4k7iygLgIVTqXmnqq4lLj1KSRKpTQlV9bmuXq
+        hqSziDccjl5SV9pXt90zjmtzNMv4Qi43V5a7GiUIo82UZjyHPgPS6KLEri1M
+        ha3hpanSfM3N2uwH/lyxxlDuTSxPcJLcm9zShG9H8LcQpjbY7k1Y6QF+HGGo
+        xPenS5v6H0cWw1z3/nTJFPnemidyyDoAkVoauZtSDbeWB4gZT1s9RoUZ2nx9
+        JKT6afEDymanUKMGVL5Q9ahHpdzdqQ3WoTIVpcWodb0W3zSqZgxi4Ez5xHaX
+        SSETz2X7TSnMeq22Z2ddAxYzDlFudgWpdQXQhEiK+QRYXwH1NCOa8tHVpgxe
+        0exA6krOVWFdDWTaIJu3UVPyw5R7puPbN7IbKCHG79W1r8TGs2gaJTp8OyY1
+        GVS/dVcpIFJfRHFghizDbJcFuO9WpULnUG3/ivXPy3rc36tzLs94Mh3fAogb
+        ULK+4gUd18kpiyeZPX4jqT8mFUoKiQ95xwXtkqdna5jaZ1oz6wJnPqfppqrU
+        43IVaIAMN/JuAEzH992/OrXT8c4aTWsZdE0tawGBWukRvxU02ybwWRPmP3Ta
+        vJY338oaMaNZlGyIawOGmeGkxoNabTgxcb1Lr4wp1ugXwRJc9MKlWV0SU8hS
+        YSBqcexCbuDpKs2KI6dsPOMLE5d+RImibqGaI2ohN1+0iKzcSstBvXJtryV4
+        FZjpGlMhUWRqgq4iCjl70+Ib4/cLxnLJ93Ix72FtMU90o2D/i17GCy+F99U1
+        vCjce9i6gPdFttxYtJNrdl4UnKjlOjy+lsY0xyzDqg8RWAtIBR4yOLljJU4u
+        xN3UFuIMvWvXrVizADT1JbhNcdRtQ/VYWcQHzf9OZ/26YU7Q9Z5dQbBM8RAQ
+        zfVJuQ8pjAQPCZVOf9YfawSrCHiaRUG7q1rZvVokoMIOE2wai1s1v1nTtPtF
+        GqBDN8YvKfT3Qb0dE8e13QP413RHm1jLIL+N0jpw20A2kSmHWHM6NaYoiEZe
+        XzKi8V4Pqghq5fHaGBTQbDBeC9zsSFDqmwlbwGQRq8M5db+65mZxwoAIB02C
+        7DWKbqEQ/P629IGLuIW6F1hKXsvSDoSezfe/iT7FwZ9AH9opTMegJH3X7jmo
+        Juk39XEWBHgM8bYO3BGB4ABc6DlGnfC/1SWWZX1rb2/xcNBtfTXeV7Y2Z/Hx
+        Xs892CejoWMeuI5jjJvvNW+lf7vzKAh4frIRbUsZahGqKLuU4y+RiHLSlF5H
+        kAWb4LG4TTes4HX1emT0rfx5jV4a4mhMr+7JJrWuMCn8z8KU7hBS4Sf4BpEo
+        vq2TuB5a3kFxbVVOvdac5k6bJZlXCfVXIFZxG6GmPn6y3nDnNAoz3M/Xjr3n
+        jFaxjdsfGkRWq+zDM8Dtg0PhcRzhCe+EG0QdripbOGWBRofwtfU76L08CSv1
+        A98f/+ZJvXmkFOffeofqaZF0H6V0lzOvyENztOvHEZ6bCiMQCL826W448dzd
+        aewVYne2gWN3loBF9pzr0ZHvHgxGwYE/GNLJIDx2rgNK+yx0jgajCXNoOOy+
+        Lvt7e7brg692uk7XHfb7/cNBvzc8OOgfDYYHw9FoN/fmu7977nD3KsVhObvR
+        Iua+h13tQvSb7cJsTiFyYpAmBRgJKeY2Rb0m2+b7+mtNrvMizqM0LuMd0eo9
+        7zD6ZahdxUztXqDhQnF514xAl6pk+5eILeQu6nvIIXCnv2kj1s3C/3Wp385W
+        yaim1SM8IT9LXpBXwIeWDKSRSkfTpIX30JLY5GcG/gsYI8NY0ZCBUqPKCN0a
+        ktcM0b8isB8egU2ywpS7fuaiyKCb+lICecIXwMLq8e8Ze91G15Psv/9Lb/Xt
+        kl9l1Xiz7MdHYb2DHxqF9d0heQrpS54UOQZh/0vxl+OYrnN4VMVf+v0e8RfI
+        UWW+bcHXpuD++QIwGDiabEjy4xivcIxfqQLyiyr4Vxh2dxgmbvfIoD+PUIFo
+        wGL4S3fj2OsfWUcH7uHhYdc8PLDcYW9wuCvSxHMsxxk5rtuFB/fgaHiwtc+G
+        Xup+ejg5DEbBYHIwmLDJMRaFB+4gGI38PjsY+W73bY2ihrM+GB0euKNebzg4
+        GPXQbzsrV/0PF4ht2NjbYoaaM/iOYdj/C6nfEYhtWsB/gmBMr55Jy7SBoXyo
+        n1GoV4ec5/XTdepd7+LWdqvnLCl0pSmfayv+5TGRdRij3rg2BTBurODBeczN
+        Qa8/GjXAZTlZQeB6vukXIuf1Uj65hFFtlit84233+gy9ZYdRijwBsEGg67o9
+        524C8YjphbxJskEjHkcj6wiRQq1/Z7g9t+U9HbmVZxtj2eYusnvfm+xenWw0
+        LO8jnBhbUS7PwgA4EF+2/Br9/eHocAv6t9YLhW+dfBp/Jk9iPt2Y3M0xrY8n
+        L+aTuNwrbiC6QyTuFqp+L5G4o/qYnuLM9LfVJV9BwxB0uxrxm8clnytz8Zpe
+        RVO9tTpzx9L2qO3rjRCn7VCuPF2pLvTcyt1CDCy5uTunCSBRWzzFBDcrJsxG
+        9jwuvFHYH7JDJzhgw4MBHfYORv2JPwqG4S6dpyfAeEpZ4PaG4bAP8Q7LZxyP
+        a3J0rlIqvindf8ACs8JtInXlicqvQZRnfWgcYca6MnAbPmJzu04dCV1kNE3r
+        e6ZfPzSKELVzo89enb14CaYLfA5+rwDPrb99/5y8SEQEbUQHFxREzHCvp3F8
+        VMaStUOdbC5PNOnjm+XIFfbq1AN+lSBjAdHAinvMVFB2+17evU+O4khe4RZR
+        DWN5Khx7gxwtxW391TKV5Hn7fmYJvCKWZRnPzFW57N0zyruiCeRma3uTdyAU
+        hfwcxL1Q3rq/ps4UPmgOGmc52PhKBZpnUXLcWqtqoE474hnPot9x0jUWK/TZ
+        k9Wijd4I3PST9T3H9Y3SzQCoshetnZSH/jd7QYtU3UXArtaO1N+7K6Wbq37w
+        NefHj0HZ0HB6kMH7n4Gb9cCxI2S4h+eUX+J9QJ5J04H3SbwXYC8KyJaWvJjT
+        JW6O1yhvOf9fRqQK75SbOccTIj5uyiL3IBWT8b28joJnIiAajpcop9TaZrCr
+        5LM6T1TTopbQT8Vi4/KgqvzOykPCkgDvJ/9hlXTiuey1S/KtH1CRZeruuzpS
+        YbvW0Orpl9b77/pJ3427/A8ExFuL1V2mRQZebK/zY27o64MfksoVef9Z0tfZ
+        3yQVP1cBLPludKRxAVk27tk/vvJ6bcz53j0qrC0drsTxYEcLRF/R/rh2E7vz
+        4ewv+ud2PnU3r103ivBmHl6v7XzCG96vyq8iWPIm45cHO/j3uHlTuvWC9Opq
+        9Ja3oh+o62KNETa/10Q+je+p2OqrOqZcDAD1dqy+/fQ5+NQc70jdreFrdyNx
+        6J3u6ibolxUuH63R3hf8iMRxB88rgsPo3OzfNHSy8VEkXYynUH7m5/K0U+B9
+        ob6fHxPj5/PX5qFz2D8amWfGzcnqJhrd/1JdM5wABRSELnL/Is69R3t4uxCX
+        VvdPEOvEK6elfPW9ydpZlfIQyf6Jb7VfCocKeVnek3ev/fI4S+DGw7Qn/CPI
+        yWe+5ce8CMIMVFleQsvVDXB5rgU7DqDj1uM1Vf94yia49fyL3w32b+jGTdPH
+        m0V78iaB0Z101cXTY9qQoKEkCPUglz0l4pV8GtfjNz4cINXtrs9b1Ca0NhR3
+        2RCWef1OTQH/fkSstWwjRl2iTJZ+j+ARz9K1nNroT+V1TflRtY2fbPbTEiLP
+        yCcyv5midORB2yghjtUbDAAjUBkIi5TfGiNPQVAAsdZgsiS/vjXPC4isTQmB
+        azi4O2A6rtnrE9c57h0eOweaNomIz+XXoNTXAKa/R/LzX/8DzTrtjwxOAAA=
+    http_version: 
+  recorded_at: Fri, 23 Jan 2015 15:27:05 GMT
+recorded_with: VCR 2.9.3

--- a/lib/tapfinder/beer.rb
+++ b/lib/tapfinder/beer.rb
@@ -14,12 +14,17 @@ module Tapfinder
     end
 
     def bars
-      @doc.css('#tap-detail .tap-list .grid-list:nth-of-type(1) .panel').collect do |bar|
-        {
-          name: bar.css('h4 a[href^="/bar"]').text,
-          address: bar.css('li:nth-child(2) p').text,
-          updated_at: bar.css('.updated').text.sub(/Last Updated:\s+/,'')
-        }
+      potential_bar_list = @doc.css('#tap-detail .tap-list .grid-list:nth-of-type(1)')
+      if potential_bar_list.at_css('.events-panel').nil?
+        potential_bar_list.collect do |bar|
+          {
+            name: bar.css('h4 a[href^="/bar"]').text,
+            address: bar.css('li:nth-child(2) p').text,
+            updated_at: bar.css('.updated').text.sub(/Last Updated:\s+/,'')
+          }
+        end
+      else
+        []
       end
     end
 

--- a/test/tapfinder/beer_test.rb
+++ b/test/tapfinder/beer_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-describe Tapfinder::Beer do
+describe 'A beer that is available at bars and events' do
   before do
     VCR.use_cassette('rueuze') do
       @beer = Tapfinder::Beer.load( [ { 'link' => '/?p=41300' } ] ).first
@@ -27,6 +27,37 @@ describe Tapfinder::Beer do
 
   it 'should have the correct event list' do
     @beer.events.must_equal [
+      { name: 'Sour Bowl', bar: 'Brü Craft & Wurst', address: '1316 Chestnut St.', date: '01/25/2015' }
+    ]
+  end
+end
+
+describe 'A beer that is available only at events' do
+  before do
+    VCR.use_cassette('cantillon') do
+      @beer = Tapfinder::Beer.load( [ { 'link' => '/?p=35601' } ] ).first
+    end
+  end
+
+  it 'should have the correct name' do
+    @beer.name.must_equal 'Russian River Consecration'
+  end
+
+  it 'should have the correct style' do
+    @beer.style.must_equal 'Sour/Wild-Fermented Ale'
+  end
+
+  it 'should have the correct origin' do
+    @beer.origin.must_equal 'Santa Rosa, CA'
+  end
+
+  it 'should have the correct bar list' do
+    @beer.bars.must_equal []
+  end
+
+  it 'should have the correct event list' do
+    @beer.events.must_equal [
+      { name: 'Russian River', bar: 'Isaac Newton\'s', address: '18 South State St., ...', date: '01/31/2015' },
       { name: 'Sour Bowl', bar: 'Brü Craft & Wurst', address: '1316 Chestnut St.', date: '01/25/2015' }
     ]
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require 'simplecov'
 SimpleCov.start do
   add_filter 'vendor'
 end
-SimpleCov.minimum_coverage 90.61
+SimpleCov.minimum_coverage 91.22
 
 require 'minitest/autorun'
 require 'vcr'


### PR DESCRIPTION
The PTF beer page structure doesn't allow for a selector that
will only fetch bar listings, so the bar selector will match
event listings when no bars are present.

This updates the `Tapfinder::Beer#bars` method to return an
empty array if the matched element contains a '.events-panel'
element.