### PR TITLE
Return formatted text for hubot

### DIFF
--- a/lib/beer_bot.rb
+++ b/lib/beer_bot.rb
@@ -39,7 +39,7 @@ module BeerBot
     def handle_slack_request(params)
       if slacker.valid?(params)
         search(params) do |result|
-          slacker.respond_with(result)
+          slacker.respond_with(result, params)
         end
       end
     end

--- a/lib/beer_bot.rb
+++ b/lib/beer_bot.rb
@@ -14,13 +14,13 @@ module BeerBot
 
     get '/beers' do
       search(params) do |result|
-        json result[:beers]
+        BeerFormatter.format result[:beers]
       end
     end
 
     get '/bars' do
       search(params) do |result|
-        json result[:bars]
+        BarFormatter.format result[:bars]
       end
     end
 

--- a/test/beer_bot/beer_bot_test.rb
+++ b/test/beer_bot/beer_bot_test.rb
@@ -19,15 +19,19 @@ class BeerBotTest < Minitest::Unit::TestCase
   end
 
   def test_bars_endpoint
-    get '/bars', params=request_params
-    assert last_response.ok?
-    assert_equal last_response.body, result[:bars].to_json
+    BeerBot::BarFormatter.stub :format, 'Formatted beers' do
+      get '/bars', params=request_params
+      assert last_response.ok?
+      assert_equal last_response.body, 'Formatted beers'
+    end
   end
 
   def test_beers_endpoint
-    get '/beers', params=request_params
-    assert last_response.ok?
-    assert_equal last_response.body, result[:beers].to_json
+    BeerBot::BeerFormatter.stub :format, 'Formatted bars' do
+      get '/beers', params=request_params
+      assert last_response.ok?
+      assert_equal last_response.body, 'Formatted bars'
+    end
   end
 
   private

--- a/test/beer_bot/beer_bot_test.rb
+++ b/test/beer_bot/beer_bot_test.rb
@@ -41,7 +41,7 @@ class BeerBotTest < Minitest::Unit::TestCase
   def mock_slacker
     slacker = Minitest::Mock.new
     slacker.expect :valid?, true, [request_params]
-    slacker.expect :respond_with, nil, [result]
+    slacker.expect :respond_with, nil, [result, request_params]
     BeerBot::Slacker.expects(:new).returns(slacker)
   end
 


### PR DESCRIPTION
Rather than returning the raw JSON, which would require hubot to replicate the logic for formatting search results as markdown for Slack.