### PR TITLE
Connect to Philly Tapfinder via https

### DIFF
--- a/lib/tapfinder/search.rb
+++ b/lib/tapfinder/search.rb
@@ -16,7 +16,7 @@ module Tapfinder
     end
 
     def client
-      @client ||= RestClient::Resource.new("#{Tapfinder.host}#{Tapfinder.search_path}")
+      @client ||= RestClient::Resource.new("https://#{Tapfinder.host}#{Tapfinder.search_path}")
     end
 
     def search_terms_for(params)


### PR DESCRIPTION
At some point recently, Philly Tapfinder rolled out https support
and added 301s to redirect http => https, which caused errors in
beer_bot.  This updates to connect via https now that we can.