### PR TITLE
Use the `response_url` to post messages back to Slack

### DIFF
--- a/lib/beer_bot/response.rb
+++ b/lib/beer_bot/response.rb
@@ -12,8 +12,8 @@ module BeerBot
         link_names: 1,
         username: 'BeerBot',
         icon_emoji: ':beers:',
-        channel: @request_params['channel_id'],
-        text: Formatter.format(@result, @request_params)
+        text: Formatter.format(@result, @request_params),
+        response_type: 'ephemeral'
       }.to_json
     end
   end

--- a/lib/beer_bot/slacker.rb
+++ b/lib/beer_bot/slacker.rb
@@ -7,17 +7,11 @@ module BeerBot
 
     def respond_with(result, params)
       response = BeerBot::Response.new(result, params)
-      RestClient.post web_hook_url, response.to_json
+      RestClient.post params['response_url'], response.to_json
     end
 
     def valid?(params)
       params['token'] == ENV['SLACK_TOKEN']
-    end
-
-  private
-
-    def web_hook_url
-      "https://hooks.slack.com/services#{ENV['INCOMING_WEBHOOK_PATH']}"
     end
   end
 end


### PR DESCRIPTION
Slack webhooks no longer allow you to override the default channel
for the webhook, which means we can't use a pre-registered hook to
reply to a user in the same place where they used the slash command.

Instead, we can use the `response_url` parameter from the request
that is received from Slack; this parameter contains the URL for a
temporary webhook that posts back to the same channel where the user
ran their slash command.